### PR TITLE
Add admin bypass permission for locked chests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>jonyboylovespie.lockedchestplugin</groupId>
   <artifactId>LockedChestsPlugin</artifactId>
-  <version>1.3</version>
+  <version>1.4</version>
   <packaging>jar</packaging>
 
   <name>LockedChestsPlugin</name>

--- a/src/main/java/jonyboylovespie/lockedchestplugin/lockedChestsPlugin/BlockSecurityListener.java
+++ b/src/main/java/jonyboylovespie/lockedchestplugin/lockedChestsPlugin/BlockSecurityListener.java
@@ -22,6 +22,8 @@ import java.util.*;
 
 public class BlockSecurityListener implements Listener, CommandExecutor
 {
+    private static final String BYPASS_PERMISSION = "lockedchests.admin.bypass";
+
     private JavaPlugin plugin;
     private NamespacedKey ownerKey;
     private NamespacedKey trustedKey;
@@ -92,7 +94,12 @@ public class BlockSecurityListener implements Listener, CommandExecutor
 
     private boolean canPlayerOpen(Player player, TileState state)
     {
-        return isPlayerOwner(player.getUniqueId(), state) || isPlayerTrusted(player.getUniqueId(), state);
+        return hasBypassPermission(player) || isPlayerOwner(player.getUniqueId(), state) || isPlayerTrusted(player.getUniqueId(), state);
+    }
+
+    private boolean hasBypassPermission(Player player)
+    {
+        return player.hasPermission(BYPASS_PERMISSION);
     }
 
     private boolean isPlayerTrusted(UUID uuid, TileState state)
@@ -156,7 +163,7 @@ public class BlockSecurityListener implements Listener, CommandExecutor
             player.sendMessage(ChatColor.RED + "This " + getContainerType(state).toLowerCase() + " is not locked.");
             return;
         }
-        if (!isPlayerOwner(player.getUniqueId(), state) && !player.isOp())
+        if (!isPlayerOwner(player.getUniqueId(), state) && !hasBypassPermission(player))
         {
             player.sendMessage(ChatColor.RED + "You cannot unlock this " + getContainerType(state).toLowerCase() + ", it is locked by " + Bukkit.getOfflinePlayer(UUID.fromString(ownerUUID)).getName());
             return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: LockedChestsPlugin
-version: '1.3'
+version: '1.4'
 main: jonyboylovespie.lockedchestplugin.lockedChestsPlugin.LockedChestsPlugin
 api-version: '1.21'
 commands:
@@ -12,3 +12,7 @@ commands:
   lockinspect:
     description: Inspect owner.
     usage: /lockinspect
+permissions:
+  lockedchests.admin.bypass:
+    description: Allows opening locked containers without owning them.
+    default: op


### PR DESCRIPTION
Added permission: lockedchests.admin.bypass
Players with this permission can:
Open locked chests without ownership checks
Remove locks from chests regardless of ownership
Integrated permission check into existing lock validation logic